### PR TITLE
Handle trailing slashes in server URL for Ntfy client

### DIFF
--- a/src/utils/ntfy.ts
+++ b/src/utils/ntfy.ts
@@ -7,7 +7,8 @@ export class NtfyClient {
       const settings = await loadSettings();
       
       // Build URL with query parameters for title and tags
-      let url = `${settings.server}/${settings.topic}`;
+      const server = settings.server.endsWith('/') ? settings.server.slice(0, -1) : settings.server;
+      let url = `${server}/${settings.topic}`;
       const queryParams = [];
       
       if (title) {

--- a/tests/ntfy.test.ts
+++ b/tests/ntfy.test.ts
@@ -47,4 +47,36 @@ describe('NtfyClient', () => {
       }
     );
   });
+
+  test('should handle server URLs with trailing slash', async () => {
+    mockPost.mockReset();
+    const mockLoadSettings = mock(() => Promise.resolve({
+      server: 'https://test.example.com/',
+      topic: 'test-topic'
+    }));
+
+    mock.module('../src/utils/settings', () => ({
+      loadSettings: mockLoadSettings
+    }));
+
+    mock.module('axios', () => ({
+      default: { post: mockPost },
+      post: mockPost
+    }));
+
+    const client = new NtfyClient();
+    const message = 'Another test';
+
+    await client.sendMessage(message);
+
+    expect(mockPost).toHaveBeenCalledWith(
+      'https://test.example.com/test-topic',
+      message,
+      {
+        headers: {
+          'Content-Type': 'text/plain'
+        }
+      }
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Normalize server URLs by trimming trailing slashes before sending notifications
- Test that NtfyClient builds correct URL when server includes a trailing slash

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68a8b10990bc832b883479b7a0166d1d